### PR TITLE
fix: only include entry plugins which are not false

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
             ("parsers", "{{cookiecutter.include_parser}}"),
             ("apps", "{{cookiecutter.include_app}}"),
         ]
-        if condition
+        if condition != "False"
     ]
     module_name = "nomad_{{cookiecutter.module_name}}"
     src_path = os.path.join(root, "src", module_name)


### PR DESCRIPTION
Resolves #3 

I expected cookie cutter to have coerced the "False" to a boolean but that does not seem to be the case.

General todo for another PR: have an end to end test setup