### PR TITLE
Minor updates to docs and template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,5 +18,8 @@
     "include_app": true,
     "_copy_without_render": [
         "*.html"
-    ]
+    ],
+    "__prompts__": {
+        "module_name": "module_name (recommended: press enter to use the default module name)"
+    }
 }

--- a/nomad-{{cookiecutter.plugin_name}}/mkdocs.yml
+++ b/nomad-{{cookiecutter.plugin_name}}/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: {{cookiecutter.short_description}}
 site_author: {{cookiecutter.full_name}}
 
 repo_url: https://github.com/{{cookiecutter.github_username}}/nomad-{{cookiecutter.plugin_name}}
+edit_uri: ""
 
 nav:
   - Home: index.md
@@ -28,6 +29,8 @@ theme:
   features:
     - navigation.instant
   custom_dir: docs/theme
+  icon:
+    repo: fontawesome/brands/github
 markdown_extensions:
   - attr_list
   - md_in_html

--- a/nomad-{{cookiecutter.plugin_name}}/py_sources/tests/apps/test_app.py
+++ b/nomad-{{cookiecutter.plugin_name}}/py_sources/tests/apps/test_app.py
@@ -2,3 +2,5 @@ def test_importing_app():
     # this will raise an exception if pydantic model validation fails for th app
     from nomad_{{cookiecutter.module_name}}.apps import myapp
 
+    assert myapp.app.label == 'MyApp'
+

--- a/nomad-{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/nomad-{{cookiecutter.plugin_name}}/pyproject.toml
@@ -134,3 +134,6 @@ mynormalizer = "nomad_{{cookiecutter.module_name}}.normalizers:mynormalizer"
 myapp = "nomad_{{cookiecutter.module_name}}.apps:myapp"   
 
 {%- endif %}
+[tool.cruft]
+# Avoid updating workflow files, this leads to permissions issues
+skip = [".github/*"]

--- a/nomad-{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/nomad-{{cookiecutter.plugin_name}}/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 name = "nomad-{{cookiecutter.plugin_name}}"
 description = "{{cookiecutter.short_description}}"
 version = "{{cookiecutter.version}}"
-readme = "README.rst"
+readme = "README.md"
 requires-python = ">=3.9"
 authors = [
     { name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}" },
@@ -35,7 +35,7 @@ maintainers = [
     { name = "{{cookiecutter.full_name}}", email = "{{cookiecutter.email}}" },
 ]
 license = { file = "LICENSE" }
-dependencies = ["nomad-lab>=1.2.2dev578"]
+dependencies = ["nomad-lab>=1.3.0"]
 
 [project.urls]
 Repository = "https://github.com/{{cookiecutter.github_username}}/nomad-{{cookiecutter.plugin_name}}"

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,11 @@ envlist = py39
 [testenv]
 setenv = 
     UV_EXTRA_INDEX_URL=https://gitlab.mpcdf.mpg.de/api/v4/projects/2187/packages/pypi/simple
-    UV_PRERELEASE=allow
 
 deps = pytest
        pytest-cookies
        tox
-       nomad-lab>=1.2.2dev578
+       nomad-lab>=1.3.0
 
 commands = pytest {posargs:tests}
 


### PR DESCRIPTION
Resolves #21 and #20 

Due to GitHub permissions issues being extremely strict when it comes to automated bots updating workflow files, the cruft settings are changed so that it skips `github` workflow updates in the future. 

This means current plugin users of this template won't be notified of `workflow` updates but new plugin creators would have the latest workflow files.
