### PR TITLE
Example upload update

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "full_name": "John Doe",
-    "email": "joh.doe@physik.hu-berlin.de",
+    "email": "john.doe@physik.hu-berlin.de",
     "github_username": "foo",
     "plugin_name": "foobar",
     "module_name": "{{ cookiecutter.plugin_name|lower|replace('-', '_') }}",
@@ -16,7 +16,7 @@
     "include_normalizer": true,
     "include_parser": true,
     "include_app": true,
-    "include_example_uploads": true,
+    "include_example_upload": true,
     "_copy_without_render": [
         "*.html"
     ],

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "full_name": "John Doe",
-    "email": "john.doe@physik.hu-berlin.de",
+    "email": "joh.doe@physik.hu-berlin.de",
     "github_username": "foo",
     "plugin_name": "foobar",
     "module_name": "{{ cookiecutter.plugin_name|lower|replace('-', '_') }}",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             ("normalizers", "{{cookiecutter.include_normalizer}}"),
             ("parsers", "{{cookiecutter.include_parser}}"),
             ("apps", "{{cookiecutter.include_app}}"),
-            ("example_uploads", "{{cookiecutter.include_example_uploads}}"),
+            ("example_uploads", "{{cookiecutter.include_example_upload}}"),
         ]
         if condition != "False"
     ]

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             ("normalizers", "{{cookiecutter.include_normalizer}}"),
             ("parsers", "{{cookiecutter.include_parser}}"),
             ("apps", "{{cookiecutter.include_app}}"),
-            ("example_uploads", "{{cookiecutter.include_example_uploads}}"),
+            ("example_uploads", "{{cookiecutter.include_example_upload}}"),
         ]
         if condition != "False"
     ]
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         os.makedirs(test_save_path, exist_ok=True)
         move_py_files(variant=variant, save_path=test_save_path, save_type="tests")
         if variant != "apps" and variant != "example_uploads":
-            # apps and example upoads don't have tests data
+            # apps and example uploads don't have tests data
             move_py_files(
                 variant=variant, save_path=test_data_path, save_type="tests_data"
             )

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
             ("normalizers", "{{cookiecutter.include_normalizer}}"),
             ("parsers", "{{cookiecutter.include_parser}}"),
             ("apps", "{{cookiecutter.include_app}}"),
-            ("example_uploads", "{{cookiecutter.include_example_upload}}"),
+            ("example_uploads", "{{cookiecutter.include_example_uploads}}"),
         ]
         if condition != "False"
     ]

--- a/{{cookiecutter.plugin_name}}/MANIFEST.in
+++ b/{{cookiecutter.plugin_name}}/MANIFEST.in
@@ -1,2 +1,1 @@
-recursive-include * nomad_plugin.yaml
 graft src/{{cookiecutter.module_name}}/example_uploads

--- a/{{cookiecutter.plugin_name}}/py_sources/src/example_uploads/__init__.py
+++ b/{{cookiecutter.plugin_name}}/py_sources/src/example_uploads/__init__.py
@@ -3,6 +3,8 @@ from nomad.config.models.plugins import ExampleUploadEntryPoint
 example_upload_entry_point = ExampleUploadEntryPoint(
     title='New Example Upload',
     category='Examples',
-    description='Description of this example upload.',
-    path='example_uploads/getting_started',
+    description='This example upload contains the contents of the getting_started folder.',
+    resources=[
+	    'example_uploads/getting_started/*',
+	]
 )

--- a/{{cookiecutter.plugin_name}}/py_sources/tests/example_uploads/test_example_upload.py
+++ b/{{cookiecutter.plugin_name}}/py_sources/tests/example_uploads/test_example_upload.py
@@ -1,0 +1,19 @@
+import os
+import tempfile
+from {{cookiecutter.module_name}}.example_uploads import example_upload_entry_point
+
+
+def test_example_upload():
+    """Test that all files are correctly created by the example upload.
+    Creates a temporary directory and requests the example upload
+    to load all files into it.
+    """
+    with tempfile.TemporaryDirectory() as tmp_upload_directory:
+        example_upload_entry_point.load(tmp_upload_directory)
+        real_upload_files = []
+        for dirpath, _, filenames in os.walk(tmp_upload_directory):
+            for filename in filenames:
+                real_upload_files.append(
+                    os.path.abspath(os.path.join(dirpath, filename))
+                )
+        assert sorted(real_upload_files) == ['README.md']

--- a/{{cookiecutter.plugin_name}}/py_sources/tests/example_uploads/test_example_upload.py
+++ b/{{cookiecutter.plugin_name}}/py_sources/tests/example_uploads/test_example_upload.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+
 from {{cookiecutter.module_name}}.example_uploads import example_upload_entry_point
 
 
@@ -8,12 +9,19 @@ def test_example_upload():
     Creates a temporary directory and requests the example upload
     to load all files into it.
     """
+    # We set the plugin package name manually in testing: normally it is
+    # resolved automatically during the plugin entry point loading
+    example_upload_entry_point.plugin_package = '{{cookiecutter.module_name}}'
+
     with tempfile.TemporaryDirectory() as tmp_upload_directory:
         example_upload_entry_point.load(tmp_upload_directory)
-        real_upload_files = []
+        relative_paths = []
         for dirpath, _, filenames in os.walk(tmp_upload_directory):
             for filename in filenames:
-                real_upload_files.append(
-                    os.path.abspath(os.path.join(dirpath, filename))
-                )
-        assert sorted(real_upload_files) == ['README.md']
+
+                full_path = os.path.join(dirpath, filename)
+                relative_path = os.path.relpath(full_path, tmp_upload_directory)
+                relative_paths.append(relative_path)
+
+        assert sorted(relative_paths) == ['README.md']
+

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,10 +121,10 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{%if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif -%}
-{%if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif -%}
-{%if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif -%}
-{%if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif -%}
+{%if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif %}
+{%if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif %}
+{%if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif %}
+{%if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif %}
 {%if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif%}
 
 [tool.cruft]

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,11 +121,21 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{% if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{%- endif -%}
-{%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{%- endif -%}
-{%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{%- endif -%}
-{%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{%- endif -%}
-{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{%- endif %}
+{% if cookiecutter.include_parser -%}
+parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
+{%- endif -%}
+{% if cookiecutter.include_schema_package -%}
+schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"
+{%- endif -%}
+{% if cookiecutter.include_normalizer -%}
+normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"
+{%- endif -%}
+{% if cookiecutter.include_app -%}
+app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"
+{%- endif -%}
+{% if cookiecutter.include_example_upload -%}
+example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
+{%- endif %}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,19 +121,19 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{% if cookiecutter.include_parser -%}
+{%- if cookiecutter.include_parser %}
 parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
 {%- endif -%}
-{% if cookiecutter.include_schema_package -%}
+{% if cookiecutter.include_schema_package %}
 schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"
 {%- endif -%}
-{% if cookiecutter.include_normalizer -%}
+{% if cookiecutter.include_normalizer %}
 normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"
 {%- endif -%}
-{% if cookiecutter.include_app -%}
+{% if cookiecutter.include_app %}
 app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"
 {%- endif -%}
-{% if cookiecutter.include_example_upload -%}
+{% if cookiecutter.include_example_upload %}
 example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
 {%- endif %}
 

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,21 +121,21 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{% if cookiecutter.include_schema_package %}
+{%- if cookiecutter.include_schema_package %}
 schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"
-{% endif -%}
+{%- endif -%}
 {% if cookiecutter.include_parser %}
 parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
-{% endif -%}
+{%- endif -%}
 {% if cookiecutter.include_normalizer %}
 normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"
-{% endif -%}
+{%- endif -%}
 {% if cookiecutter.include_app %}
 app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"
-{% endif -%}
+{%- endif -%}
 {% if cookiecutter.include_example_upload %}
 example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
-{% endif %}
+{%- endif %}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,11 +121,11 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{%if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif %}
-{%if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif %}
-{%if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif %}
-{%if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif %}
-{%if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif%}
+{%- if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{%- endif -%}
+{%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{%- endif -%}
+{%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{%- endif -%}
+{%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{%- endif -%}
+{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{%- endif -%}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,21 +121,12 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{% if cookiecutter.include_parser  -%}
-parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
-{%- endif %}
-{% if cookiecutter.include_schema_package  -%}
-schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"
-{%- endif %}
-{% if cookiecutter.include_normalizer  -%}
-normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"
-{%- endif %}
-{% if cookiecutter.include_app  -%}
-app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"   
-{%- endif %}
-{% if cookiecutter.include_example_upload  -%}
-example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
-{%- endif %}
+{%- if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif -%}
+{%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif -%}
+{%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif -%}
+{%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif -%}
+{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif -%}
+
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues
 skip = [".github/*"]

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,21 +121,21 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{%- if cookiecutter.include_parser %}
-parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
-{%- endif -%}
 {% if cookiecutter.include_schema_package %}
 schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"
-{%- endif -%}
+{% endif -%}
+{% if cookiecutter.include_parser %}
+parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"
+{% endif -%}
 {% if cookiecutter.include_normalizer %}
 normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"
-{%- endif -%}
+{% endif -%}
 {% if cookiecutter.include_app %}
 app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"
-{%- endif -%}
+{% endif -%}
 {% if cookiecutter.include_example_upload %}
 example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
-{%- endif %}
+{% endif %}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,11 +121,11 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{%- if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{%- endif -%}
+{% if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{%- endif -%}
 {%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{%- endif -%}
 {%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{%- endif -%}
 {%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{%- endif -%}
-{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{%- endif -%}
+{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{%- endif %}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -122,10 +122,10 @@ where = ["src"]
 
 [project.entry-points.'nomad.plugin']
 {%if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif -%}
-{%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif -%}
-{%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif -%}
-{%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif -%}
-{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif%}
+{%if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif -%}
+{%if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif -%}
+{%if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif -%}
+{%if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif%}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -133,7 +133,7 @@ normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_en
 {% if cookiecutter.include_app  -%}
 app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"   
 {%- endif %}
-{% if cookiecutter.include_example_uploads  -%}
+{% if cookiecutter.include_example_upload  -%}
 example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
 {%- endif %}
 [tool.cruft]

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -133,7 +133,7 @@ normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_en
 {% if cookiecutter.include_app  -%}
 app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"   
 {%- endif %}
-{% if cookiecutter.include_example_upload  -%}
+{% if cookiecutter.include_example_uploads  -%}
 example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"
 {%- endif %}
 [tool.cruft]

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -121,11 +121,11 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-{%- if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif -%}
+{%if cookiecutter.include_parser -%}parser_entry_point = "{{cookiecutter.module_name}}.parsers:parser_entry_point"{% endif -%}
 {%- if cookiecutter.include_schema_package -%}schema_package_entry_point = "{{cookiecutter.module_name}}.schema_packages:schema_package_entry_point"{% endif -%}
 {%- if cookiecutter.include_normalizer -%}normalizer_entry_point = "{{cookiecutter.module_name}}.normalizers:normalizer_entry_point"{% endif -%}
 {%- if cookiecutter.include_app -%}app_entry_point = "{{cookiecutter.module_name}}.apps:app_entry_point"{% endif -%}
-{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif -%}
+{%- if cookiecutter.include_example_upload -%}example_upload_entry_point = "{{cookiecutter.module_name}}.example_uploads:example_upload_entry_point"{% endif%}
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues


### PR DESCRIPTION
Updated example upload to use the `resources` parameter instead of `path`, added a simple example test for example uploads, fixed misc. typos/template issues.