### PR TITLE
 Add CITATION.cff Support and Fix License/Workflow Issues

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,9 +8,9 @@
     "version": "0.1.0",
     "license": [
         "MIT",
-        "BSD-3",
-        "GNU GPL v3.0+",
-        "Apache Software License 2.0"
+        "BSD-3-Clause",
+        "GPL-3.0+",
+        "Apache-2.0"
     ],
     "include_schema_package": true,
     "include_normalizer": true,
@@ -20,6 +20,7 @@
     "include_action": true,
     "include_north_tools": false,
     "north_tool_name": "my_north_tool",
+    "include_citation_file": false,
     "_copy_without_render": [
         "*.html",
         "*.png"
@@ -29,6 +30,7 @@
         "github_username": "Github organization or profile name, default: foo",
         "include_action": "Include NOMAD Actions (NEW in nomad-lab v1.4+)",
         "include_north_tools": "Include NOMAD North Tools (NEW in nomad-lab v1.4+)",
-        "north_tool_name": "Name of the NORTH tool to be displayed in the list of NOMAD NORTH tools. For include_north_tools == n, this will be ignored."
+        "north_tool_name": "Name of the NORTH tool to be displayed in the list of NOMAD NORTH tools. For include_north_tools == n, this will be ignored.",
+        "include_citation_file": "Include a zenodo compatible CITATION.cff file for the plugin."
     }
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -31,6 +31,6 @@
         "include_action": "Include NOMAD Actions (NEW in nomad-lab v1.4+)",
         "include_north_tools": "Include NOMAD North Tools (NEW in nomad-lab v1.4+)",
         "north_tool_name": "Name of the NORTH tool to be displayed in the list of NOMAD NORTH tools. For include_north_tools == n, this will be ignored.",
-        "include_citation_file": "Include a zenodo compatible CITATION.cff file for the plugin."
+        "include_citation_file": "Include a CITATION.cff file for the plugin."
     }
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     variants = [
         variant
         for variant, condition in [
+            ("citation", "{{cookiecutter.include_citation_file}}"),
             ("north_tools", "{{cookiecutter.include_north_tools}}"),
             ("schema_packages", "{{cookiecutter.include_schema_package}}"),
             ("normalizers", "{{cookiecutter.include_normalizer}}"),
@@ -81,6 +82,11 @@ if __name__ == "__main__":
             variant="publish_north.yml", save_type="north_sources", save_path=os.path.join(root, ".github", "workflows")
         )
         move_py_files(variant=".dockerignore", save_type="north_sources", save_path=root)
+    if "citation" in variants:
+        move_py_files(
+            variant="cff_validation.yml", save_type="citation_sources", save_path=os.path.join(root, ".github", "workflows")
+        )
+        move_py_files(variant="CITATION.cff", save_type="citation_sources", save_path=root)
         
     remove_temp_folders(ALL_TEMP_FOLDERS)
     

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     variants = [
         variant
         for variant, condition in [
-            ("citation", "{{cookiecutter.include_citation_file}}"),
+            ("citation_cff", "{{cookiecutter.include_citation_file}}"),
             ("north_tools", "{{cookiecutter.include_north_tools}}"),
             ("schema_packages", "{{cookiecutter.include_schema_package}}"),
             ("normalizers", "{{cookiecutter.include_normalizer}}"),
@@ -82,7 +82,7 @@ if __name__ == "__main__":
             variant="publish_north.yml", save_type="north_sources", save_path=os.path.join(root, ".github", "workflows")
         )
         move_py_files(variant=".dockerignore", save_type="north_sources", save_path=root)
-    if "citation" in variants:
+    if "citation_cff" in variants:
         move_py_files(
             variant="cff_validation.yml", save_type="citation_sources", save_path=os.path.join(root, ".github", "workflows")
         )

--- a/tests/test_create_template.py
+++ b/tests/test_create_template.py
@@ -51,6 +51,10 @@ def run_tox(plugin):
     "north_tool_name",
     ["MyNorthTool", "AnotherTool"],
 )
+@pytest.mark.parametrize(
+    "include_citation_file",
+    [True, False],
+)
 def test_run_cookiecutter_and_plugin_tests(
     cookies,
     plugin_name,
@@ -60,6 +64,7 @@ def test_run_cookiecutter_and_plugin_tests(
     include_schema_package,
     include_north_tools,
     north_tool_name,
+    include_citation_file,
 ):
     """Create a new plugin via cookiecutter and run its tests."""
     result = cookies.bake(
@@ -71,6 +76,7 @@ def test_run_cookiecutter_and_plugin_tests(
             "include_schema_package": str(include_schema_package),
             "include_north_tools": str(include_north_tools),
             "north_tool_name": str(north_tool_name),
+            "include_citation_file": str(include_citation_file),
         }
     )
     module_name = plugin_name.replace("-", "_")
@@ -154,6 +160,12 @@ def test_run_cookiecutter_and_plugin_tests(
         assert not result.project_path.joinpath(
             ".github", "workflows", "publish_north.yaml"
         ).is_file()
+
+    if include_citation_file:
+        assert result.project_path.joinpath("CITATION.cff").is_file()
+        assert result.project_path.joinpath(".github", "workflows", "cff_validation.yml").is_file()
+    else:
+        assert not result.project_path.joinpath("CITATION.cff").is_file()
 
     if include_app and include_parser and include_normalizer and include_schema_package and include_north_tools:
         run_tox(str(result.project_path))

--- a/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           name: dist-artifacts
           path: dist/
 
-  {if cookiecutter.include_citation_file %}cff-version-check:
+  {% if cookiecutter.include_citation_file %}cff-version-check:
     name: Check cff-version
     runs-on: ubuntu-latest
     outputs:

--- a/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
@@ -41,6 +41,39 @@ jobs:
           name: dist-artifacts
           path: dist/
 
+  {if cookiecutter.include_citation_file %}cff-version-check:
+    name: Check cff-version
+    runs-on: ubuntu-latest
+    outputs:
+      git_tag_version: {% raw %}${{ steps.git_tag_version.outputs.version }}{% endraw %}
+      citation_version: {% raw %}${{ steps.citation_version.outputs.version }}{% endraw %}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Install uv and set the python version to {% raw %}${{ env.python-version }}{% endraw %}
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: {% raw %}${{ env.python-version }}{% endraw %}
+      - name: Git tag version
+        id: git_tag_version
+        run: |
+          GIT_TAG_VERSION={%raw%}${GITHUB_REF#refs/tags/v}{%endraw%}
+          echo "version=$GIT_TAG_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Citation version
+        id: citation_version
+        run: |
+          CITATION_VERSION=$(grep '^version:' CITATION.cff | cut -d' ' -f2)
+          echo "version=$CITATION_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Fail if versions mismatch
+        run: |
+        {% raw %}if [ "${{ steps.git_tag_version.outputs.version }}" != "${{ steps.citation_version.outputs.version }}" ]; then
+            echo "Version mismatch: Git tag is ${{ steps.git_tag_version.outputs.version }}, CITATION.cff is ${{ steps.citation_version.outputs.version }}"
+            exit 1
+          fi{% endraw %}{% endif %}
+
   # deploy:
   #   name: Upload to PyPI
   #   needs: build

--- a/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Fail if versions mismatch
         run: |
-        {% raw %}if [ "${{ steps.git_tag_version.outputs.version }}" != "${{ steps.citation_version.outputs.version }}" ]; then
+          {% raw %}if [ "${{ steps.git_tag_version.outputs.version }}" != "${{ steps.citation_version.outputs.version }}" ]; then
             echo "Version mismatch: Git tag is ${{ steps.git_tag_version.outputs.version }}, CITATION.cff is ${{ steps.citation_version.outputs.version }}"
             exit 1
           fi{% endraw %}{% endif %}

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
@@ -14,7 +14,6 @@ repository-code: https://github.com/{{cookiecutter.github_username}}/{{cookiecut
 url: https://zenodo.org/records/0000000
 keywords:
   - keyword1
-  - keyword2
 abstract:
   This is a template for a CITATION.cff file. Please edit the fields accordingly.
 license: {{cookiecutter.license}}

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
@@ -6,8 +6,8 @@ message:
   metadata from this file.
 type: software
 authors:
-  - given-names: {{cookiecutter.full_name | trim | split(' ')[0]}}
-    family-names: {{cookiecutter.full_name | trim | split(' ')[-1]}}
+  - given-names: {{(cookiecutter.full_name | trim).split(' ')[0]}}
+    family-names: {{(cookiecutter.full_name | trim).split(' ')[-1]}}
     orcid: 'https://orcid.org/0000-0000-0000-0000'
 doi: 10.5281/zenodo.0000000
 repository-code: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+title: '{{cookiecutter.plugin_name}}: A NOMAD plugin for ...'
+version: 0.1.0
+message:
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: {{cookiecutter.full_name | trim | split(' ')[0]}}
+    family-names: {{cookiecutter.full_name | trim | split(' ')[-1]}}
+    orcid: 'https://orcid.org/0000-0000-0000-0000'
+doi: 10.5281/zenodo.0000000
+repository-code: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.plugin_name}}
+url: https://zenodo.org/records/0000000
+keywords:
+  - keyword1
+  - keyword2
+abstract:
+  This is a template for a CITATION.cff file. Please edit the fields accordingly.
+license: {{cookiecutter.license}}
+funding:
+  - name: Funding Agency
+    award: 123456

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
@@ -1,0 +1,51 @@
+name: Validate CITATION.cff
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "CITATION.cff"
+      - ".github/workflows/cff-validation.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "CITATION.cff"
+      - ".github/workflows/cff-validation.yml"
+
+env:
+  UV_VERSION: 0.9
+  PYTHON_VERSION: 3.12
+
+jobs:
+  validate-cff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+            version: {% raw -%}${{ env.UV_VERSION }}{% endraw %}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+            python-version: {% raw -%}${{ env.PYTHON_VERSION }}{% endraw %}
+
+      - name: Install cffconvert
+        run: |
+          uv pip install cffconvert
+
+      - name: Validate CITATION.cff
+        run: |
+          cffconvert --validate
+
+      - name: Test Zenodo conversion
+        run: |
+          # Remove the funding section to avoid validation issues with Zenodo
+          head -n $(($(grep -n "^funding:" CITATION.cff | cut -d: -f1) - 1)) CITATION.cff > temp && mv temp CITATION.cff
+
+          cffconvert --validate --format zenodo || exit 1

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
@@ -15,7 +15,6 @@ on:
       - ".github/workflows/cff-validation.yml"
 
 env:
-  UV_VERSION: 0.9
   PYTHON_VERSION: 3.12
 
 jobs:
@@ -26,9 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-            version: {% raw -%}${{ env.UV_VERSION }}{% endraw %}
+        uses: astral-sh/setup-uv@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
@@ -36,13 +36,9 @@ jobs:
         run: |
           uv pip install cffconvert
 
-      - name: Validate CITATION.cff
-        run: |
-          cffconvert --validate
-
       - name: Test Zenodo conversion
         run: |
           # Remove the funding section to avoid validation issues with Zenodo
-          head -n $(($(grep -n "^funding:" CITATION.cff | cut -d: -f1) - 1)) CITATION.cff > temp && mv temp CITATION.cff
+          sed -i '/^funding:/,$d' CITATION.cff
 
           cffconvert --validate --format zenodo || exit 1

--- a/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
+++ b/{{cookiecutter.plugin_name}}/py_sources/citation_sources/cff_validation.yml
@@ -26,19 +26,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
         with:
             python-version: {% raw -%}${{ env.PYTHON_VERSION }}{% endraw %}
-
-      - name: Install cffconvert
-        run: |
-          uv pip install cffconvert
 
       - name: Test Zenodo conversion
         run: |
           # Remove the funding section to avoid validation issues with Zenodo
           sed -i '/^funding:/,$d' CITATION.cff
 
-          cffconvert --validate --format zenodo || exit 1
+          uv run --with cffconvert cffconvert --validate --format zenodo || exit 1


### PR DESCRIPTION
This PR addresses #74.

This PR introduces citation file support to the NOMAD plugin cookiecutter template and addresses several related steps to ensure proper template rendering and GitHub Actions workflow execution.

- [x] Updated license identifiers in cookiecutter.json to follow SPDX standards:

  "MIT" → "MIT"
  "BSD-3" → "BSD-3-Clause"
  "GNU GPL v3.0+" → "GPL-3.0+"
  "Apache Software License 2.0" → "Apache-2.0"

- [x] Added CITATION.cff and GitHub workflow

- [x] Added corresponding test (include and exclude citation)

For execution of the PR, please follow: PR: https://github.com/FAIRmat-NFDI/foobar/pull/4